### PR TITLE
Return signatures order by most recent by default

### DIFF
--- a/django/crashreport/stats/views.py
+++ b/django/crashreport/stats/views.py
@@ -122,6 +122,7 @@ class SignatureView(ListViewBase):
         if version is not None:
             version_filter_params = Version.get_filter_params(version, prefix='version__')
             crashes = crashes.filter(**version_filter_params)
+        crashes = crashes.order_by("-upload_time")
         return crashes
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Order crashes in signature view by most recent.

E.g. https://crashreport.libreoffice.org/stats/signature/vcl::Window::GetParentWithLOKNotifier()